### PR TITLE
Authorwise Config (BTO only)

### DIFF
--- a/DiscordAlertsTrader/alerts_trader.py
+++ b/DiscordAlertsTrader/alerts_trader.py
@@ -423,7 +423,7 @@ class AlertsTrader():
                     max_trade_vals = eval(self.cfg["order_configs"]["max_trade_capital"])
                     max_trade_val = float(max_trade_vals.get(order["Trader"], max_trade_vals["default"]))
                     default_bto_qtys = eval(self.cfg["order_configs"]["default_bto_qty"])
-                    default_bto_qty = float(default_bto_qtys.get(order["Trader"], default_bto_qtys["default"]))
+                    default_bto_qty = default_bto_qtys.get(order["Trader"], default_bto_qtys["default"])
                     trade_capitals = eval(self.cfg["order_configs"]["trade_capital"])
                     trade_capital = float(trade_capitals.get(order["Trader"], trade_capitals["default"]))
                     

--- a/DiscordAlertsTrader/alerts_trader.py
+++ b/DiscordAlertsTrader/alerts_trader.py
@@ -421,22 +421,11 @@ class AlertsTrader():
                     price = price*100 if order["asset"] == "option" else price
 
                     max_trade_vals = eval(self.cfg["order_configs"]["max_trade_capital"])
-                    if order["Trader"] in max_trade_vals.keys():
-                        max_trade_val = float(max_trade_vals[order["Trader"]])
-                    else:
-                        max_trade_val = float(max_trade_vals["default"])
-                    
+                    max_trade_val = float(max_trade_vals.get(order["Trader"], max_trade_vals["default"]))
                     default_bto_qtys = eval(self.cfg["order_configs"]["default_bto_qty"])
-                    if order["Trader"] in default_bto_qtys.keys():
-                        default_bto_qty = float(default_bto_qtys[order["Trader"]])
-                    else:
-                        default_bto_qty = float(default_bto_qtys["default"])
-
+                    default_bto_qty = float(default_bto_qtys.get(order["Trader"], default_bto_qtys["default"]))
                     trade_capitals = eval(self.cfg["order_configs"]["trade_capital"])
-                    if order["Trader"] in trade_capitals.keys():
-                        trade_capital = float(trade_capitals[order["Trader"]])
-                    else:
-                        trade_capital = float(trade_capitals["default"])
+                    trade_capital = float(trade_capitals.get(order["Trader"], trade_capitals["default"]))
                     
                     if 'Qty' not in order.keys() or order['Qty'] is None:
                         if default_bto_qty == "buy_one":

--- a/DiscordAlertsTrader/alerts_trader.py
+++ b/DiscordAlertsTrader/alerts_trader.py
@@ -419,13 +419,30 @@ class AlertsTrader():
                         self.queue_prints.put([str_msg, "", "red"])
                         return "no", order, False
                     price = price*100 if order["asset"] == "option" else price
-                    max_trade_val = float(self.cfg['order_configs']['max_trade_capital'])
+
+                    max_trade_vals = eval(self.cfg["order_configs"]["max_trade_capital"])
+                    if order["Trader"] in max_trade_vals.keys():
+                        max_trade_val = float(max_trade_vals[order["Trader"]])
+                    else:
+                        max_trade_val = float(max_trade_vals["default"])
+                    
+                    default_bto_qtys = eval(self.cfg["order_configs"]["default_bto_qty"])
+                    if order["Trader"] in default_bto_qtys.keys():
+                        default_bto_qty = float(default_bto_qtys[order["Trader"]])
+                    else:
+                        default_bto_qty = float(default_bto_qtys["default"])
+
+                    trade_capitals = eval(self.cfg["order_configs"]["trade_capital"])
+                    if order["Trader"] in trade_capitals.keys():
+                        trade_capital = float(trade_capitals[order["Trader"]])
+                    else:
+                        trade_capital = float(trade_capitals["default"])
                     
                     if 'Qty' not in order.keys() or order['Qty'] is None:
-                        if self.cfg['order_configs']['default_bto_qty'] == "buy_one":
+                        if default_bto_qty == "buy_one":
                             order['Qty'] = 1                    
-                        elif self.cfg['order_configs']['default_bto_qty'] == "trade_capital":
-                            order['Qty'] =  int(max(round(float(self.cfg['order_configs']['trade_capital'])/price), 1))
+                        elif default_bto_qty == "trade_capital":
+                            order['Qty'] =  int(max(round(trade_capital/price), 1))
                     # elif self.cfg['order_configs']['default_bto_qty'] == "trade_capital":
                     #     order['Qty'] =  int(max(round(float(self.cfg['order_configs']['trade_capital'])/price), 1))
                     

--- a/DiscordAlertsTrader/config_example.ini
+++ b/DiscordAlertsTrader/config_example.ini
@@ -99,14 +99,20 @@ exclude_tickers =
 min_opt_price = 10
 
 # if no quantity specified in the alert either "buy_one" or use "trade_capital" to calculate quantity
-default_bto_qty = buy_one
+# authorwise config example:
+# default_bto_qty = {"default": "buy_one", "Sir Goldman Alert Bot#9871": "trade_capital"}
+default_bto_qty = {"default": "buy_one"}
 
 # if default_bto_qty = trade_capital, specify the $ amount per trade, it will calculate the quantity
-trade_capital = 300
+# authorwise config example:
+# trade_capital = {"default": 300, "Chis Trades000": 200}
+trade_capital = {"default": 300}
 
 # Maximum $ per trade, set it to 4% of your portfolio. If the alert quantity is higher than this
 # it will only buy the max_trade_capital, if one contract is higher than this it will not buy
-max_trade_capital = 1000
+# authorwise config example:
+# max_trade_capital = {"default": 1000, "lordvader32": 1200}
+max_trade_capital = {"default": 1000}
 
 [portfolio_names]
 # name extension has to be .csv, no need to change

--- a/DiscordAlertsTrader/config_example.ini
+++ b/DiscordAlertsTrader/config_example.ini
@@ -100,7 +100,7 @@ min_opt_price = 10
 
 # if no quantity specified in the alert either "buy_one" or use "trade_capital" to calculate quantity
 # authorwise config example:
-# default_bto_qty = {"default": "buy_one", "Sir Goldman Alert Bot#9871": "trade_capital"}
+# default_bto_qty = {"default": "buy_one", "Chis Trades000": "trade_capital"}
 default_bto_qty = {"default": "buy_one"}
 
 # if default_bto_qty = trade_capital, specify the $ amount per trade, it will calculate the quantity


### PR DESCRIPTION
Allows for author-specific order config in config.ini. Alerts_trader.py checks for trader in config dictionary, use if exists else default. Do not remove default key!

config.ini
```
# if no quantity specified in the alert either "buy_one" or use "trade_capital" to calculate quantity
# authorwise config example
# default_bto_qty = {"default": "trade_capital", "Sir Goldman Alert Bot#9871": "buy_one"}
default_bto_qty = {"default": "trade_capital"}

# if default_bto_qty = trade_capital, specify the $ amount per trade, it will calculate the quantity
# authorwise config example
# trade_capital = {"default": 160, "Chis Trades000": 200}
trade_capital = {"default": 120}

# Maximum $ per trade, set it to 4% of your portfolio. If the alert quantity is higher than this
# it will only buy the max_trade_capital, if one contract is higher than this it will not buy
# authorwise config example
# max_trade_capital = {"default": 160, "lordvader32": 200}
max_trade_capital = {"default": 200}
```